### PR TITLE
Check if view has `PermissionsFilterMixin `

### DIFF
--- a/tutelary/mixins.py
+++ b/tutelary/mixins.py
@@ -128,7 +128,8 @@ class PermissionsFilterMixin:
         if permissions:
             actions = tuple(permissions.split(','))
 
-            if isinstance(self.permission_filter_queryset, Sequence):
+            if (hasattr(self, 'permission_filter_queryset') and
+                    isinstance(self.permission_filter_queryset, Sequence)):
                 actions += tuple(self.permission_filter_queryset)
 
             self.permission_filter_queryset = actions


### PR DESCRIPTION
Fixes a bug that prevented `PermissionsFilterMixin` from working with views that fon't have `permission_filter_queryset` explicitly set.