### PR TITLE
Simplify lookup logic

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,8 +84,8 @@ setup(
     packages=get_packages(package),
     package_data=get_package_data(package),
     install_requires=[
-        'Django==1.9',
-        'django-audit-log==0.7.0'
+        'Django>=1.9',
+        'django-audit-log>=0.7.0'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tutelary/models.py
+++ b/tutelary/models.py
@@ -149,8 +149,8 @@ class PolicyInstance(models.Model):
 
 
 def _policy_psets(policies):
-    """Find the IDs of all permission sets making use of all of a list of
-    policies.  The input is a list of (policy, variables) pairs.
+    """Find all permission sets making use of all of a list of policies. The
+    input is a list of (policy, variables) pairs.
 
     """
     if len(policies) == 0:


### PR DESCRIPTION
This PR aims to reduce the number of unnecessary lookups performed by Tutelary. The codebase has a habit of making DB queries within `for` loops (sometimes nested `for` loops). These can be avoided with query refactors.

The optimizations occurred when the system fetches and assigns policies for a user. This operation occurs every time a user model is saved (including when a user logs in, being that this saves the user model with an updated `last_login` value):

https://github.com/Cadasta/cadasta-platform/blob/ff12c1d64d52df9d74c1cda475c963a989d57e20/cadasta/accounts/models.py#L119-L125

The fact that a user's policies are re-applied at every save is questionable and will be addressed in another PR: Cadasta/cadasta-platform#1910.

The need for this refactor became evident when observing the number of database queries that occurred when a user signs-in.  Take for example, a member of programs using the demo system:

[4200 queries](https://gist.github.com/alukach/4c609d7fbb1b9bb5fb1dc67057d09573)


After these optimizations:

<details>
<summary>26 queries</summary>

```sql
(0.001) SELECT "django_site"."id", "django_site"."domain", "django_site"."name" FROM "django_site" WHERE "django_site"."id" = 1; args=(1,)
(0.002) SELECT "accounts_user"."id", "accounts_user"."password", "accounts_user"."last_login", "accounts_user"."is_superuser", "accounts_user"."username", "accounts_user"."email", "accounts_user"."is_staff", "accounts_user"."is_active", "accounts_user"."date_joined", "accounts_user"."full_name", "accounts_user"."email_verified", "accounts_user"."verify_email_by", "accounts_user"."change_pw", "accounts_user"."language", "accounts_user"."measurement", "accounts_user"."avatar", "accounts_user"."created_date", "accounts_user"."last_updated" FROM "accounts_user" WHERE "accounts_user"."username" = 'katrina'; args=('katrina',)
(0.001) SELECT (1) AS "a" FROM "account_emailaddress" WHERE ("account_emailaddress"."user_id" = 243 AND "account_emailaddress"."verified" = true) LIMIT 1; args=(243, True)
(0.001) SELECT (1) AS "a" FROM "django_session" WHERE "django_session"."session_key" = 'gwu8kjrz2wl4wq7rv7p286ljwb8gonv9' LIMIT 1; args=('gwu8kjrz2wl4wq7rv7p286ljwb8gonv9',)
(0.001) INSERT INTO "django_session" ("session_key", "session_data", "expire_date") VALUES ('gwu8kjrz2wl4wq7rv7p286ljwb8gonv9', 'ZjFlMjMwNjdjZWY3OTE5NWIzMGRiNTAyOTllOGIwZjYzZGFlZTYxODp7fQ==', '2017-12-04T21:14:30.999496+00:00'::timestamptz); args=('gwu8kjrz2wl4wq7rv7p286ljwb8gonv9', 'ZjFlMjMwNjdjZWY3OTE5NWIzMGRiNTAyOTllOGIwZjYzZGFlZTYxODp7fQ==', datetime.datetime(2017, 12, 4, 21, 14, 30, 999496, tzinfo=<UTC>))
(0.001) UPDATE "accounts_user" SET "last_login" = '2017-11-20T21:14:31.010494+00:00'::timestamptz WHERE "accounts_user"."id" = 243; args=(datetime.datetime(2017, 11, 20, 21, 14, 31, 10494, tzinfo=<UTC>), 243)
(0.001) INSERT INTO "accounts_historicaluser" ("id", "password", "last_login", "is_superuser", "username", "email", "is_staff", "is_active", "date_joined", "full_name", "email_verified", "verify_email_by", "change_pw", "language", "measurement", "avatar", "created_date", "last_updated", "history_date", "history_change_reason", "history_user_id", "history_type") VALUES (243, 'argon2$argon2i$v=19$m=512,t=2,p=2$SzdaSGhPZ21GRlBL$penj2ES65+5BRbRuUx5LWg', '2017-11-20T21:14:31.010494+00:00'::timestamptz, false, 'katrina', 'katrina@cadasta.org', false, true, '2017-03-03T22:19:51.376397+00:00'::timestamptz, 'Katrina E.', true, '2017-03-05T22:19:51.376416+00:00'::timestamptz, true, 'en', 'metric', '', '2016-01-01T00:00:00+00:00'::timestamptz, '2017-11-20T20:03:15.867336+00:00'::timestamptz, '2017-11-20T21:14:31.021588+00:00'::timestamptz, NULL, 243, '~') RETURNING "accounts_historicaluser"."history_id"; args=(243, 'argon2$argon2i$v=19$m=512,t=2,p=2$SzdaSGhPZ21GRlBL$penj2ES65+5BRbRuUx5LWg', datetime.datetime(2017, 11, 20, 21, 14, 31, 10494, tzinfo=<UTC>), False, 'katrina', 'katrina@cadasta.org', False, True, datetime.datetime(2017, 3, 3, 22, 19, 51, 376397, tzinfo=<UTC>), 'Katrina E.', True, datetime.datetime(2017, 3, 5, 22, 19, 51, 376416, tzinfo=<UTC>), True, 'en', 'metric', '', datetime.datetime(2016, 1, 1, 0, 0, tzinfo=<UTC>), datetime.datetime(2017, 11, 20, 20, 3, 15, 867336, tzinfo=<UTC>), datetime.datetime(2017, 11, 20, 21, 14, 31, 21588, tzinfo=<UTC>), None, 243, '~')
(0.001) SELECT "tutelary_policy"."id", "tutelary_policy"."name", "tutelary_policy"."body" FROM "tutelary_policy" WHERE "tutelary_policy"."name" = 'default'; args=('default',)
(0.001) SELECT "tutelary_permissionset"."id", "tutelary_permissionset"."anonymous_user" FROM "tutelary_permissionset" INNER JOIN "tutelary_permissionset_users" ON ("tutelary_permissionset"."id" = "tutelary_permissionset_users"."permissionset_id") WHERE "tutelary_permissionset_users"."user_id" = 243 ORDER BY "tutelary_permissionset"."id" ASC LIMIT 1; args=(243,)
(0.001) SELECT "tutelary_policyinstance"."id", "tutelary_policyinstance"."policy_id", "tutelary_policyinstance"."pset_id", "tutelary_policyinstance"."index", "tutelary_policyinstance"."role_id", "tutelary_policyinstance"."variables", "tutelary_policy"."id", "tutelary_policy"."name", "tutelary_policy"."body", "tutelary_role"."id", "tutelary_role"."name", "tutelary_role"."variables" FROM "tutelary_policyinstance" INNER JOIN "tutelary_policy" ON ("tutelary_policyinstance"."policy_id" = "tutelary_policy"."id") LEFT OUTER JOIN "tutelary_role" ON ("tutelary_policyinstance"."role_id" = "tutelary_role"."id") WHERE "tutelary_policyinstance"."pset_id" = 5946 ORDER BY "tutelary_policyinstance"."index" ASC; args=(5946,)
(0.001) SELECT "tutelary_permissionset"."id", "tutelary_permissionset"."anonymous_user" FROM "tutelary_permissionset" INNER JOIN "tutelary_permissionset_users" ON ("tutelary_permissionset"."id" = "tutelary_permissionset_users"."permissionset_id") WHERE "tutelary_permissionset_users"."user_id" = 243 ORDER BY "tutelary_permissionset"."id" ASC LIMIT 1; args=(243,)
(0.001) SELECT "tutelary_permissionset_users"."id", "tutelary_permissionset_users"."permissionset_id", "tutelary_permissionset_users"."user_id" FROM "tutelary_permissionset_users" WHERE ("tutelary_permissionset_users"."permissionset_id" = 5946 AND "tutelary_permissionset_users"."user_id" IN (243)); args=(5946, 243)
(0.000) DELETE FROM "tutelary_permissionset_users" WHERE "tutelary_permissionset_users"."id" IN (9333); args=(9333,)
(0.001) SELECT COUNT(*) AS "__count" FROM "accounts_user" INNER JOIN "tutelary_permissionset_users" ON ("accounts_user"."id" = "tutelary_permissionset_users"."user_id") WHERE "tutelary_permissionset_users"."permissionset_id" = 5946; args=(5946,)
(0.000) SELECT "tutelary_policyinstance"."id", "tutelary_policyinstance"."policy_id", "tutelary_policyinstance"."pset_id", "tutelary_policyinstance"."index", "tutelary_policyinstance"."role_id", "tutelary_policyinstance"."variables" FROM "tutelary_policyinstance" WHERE "tutelary_policyinstance"."pset_id" IN (5946) ORDER BY "tutelary_policyinstance"."index" ASC; args=(5946,)
(0.000) SELECT "tutelary_permissionset_users"."id", "tutelary_permissionset_users"."permissionset_id", "tutelary_permissionset_users"."user_id" FROM "tutelary_permissionset_users" WHERE "tutelary_permissionset_users"."permissionset_id" IN (5946); args=(5946,)
(0.001) DELETE FROM "tutelary_policyinstance" WHERE "tutelary_policyinstance"."id" IN (76837, 76838, 76839, 76840, 76841, 76842, 76843, 76844, 76845, 76846, 76847, 76848); args=(76837, 76838, 76839, 76840, 76841, 76842, 76843, 76844, 76845, 76846, 76847, 76848)
(0.000) DELETE FROM "tutelary_permissionset" WHERE "tutelary_permissionset"."id" IN (5946); args=(5946,)
(0.099) SELECT DISTINCT "tutelary_permissionset"."id", "tutelary_permissionset"."anonymous_user", COUNT("tutelary_policyinstance"."id") AS "num_pis" FROM "tutelary_permissionset" INNER JOIN "tutelary_policyinstance" ON ("tutelary_permissionset"."id" = "tutelary_policyinstance"."pset_id") INNER JOIN "tutelary_policyinstance" T4 ON ("tutelary_permissionset"."id" = T4."pset_id") INNER JOIN "tutelary_policyinstance" T7 ON ("tutelary_permissionset"."id" = T7."pset_id") INNER JOIN "tutelary_policyinstance" T10 ON ("tutelary_permissionset"."id" = T10."pset_id") INNER JOIN "tutelary_policyinstance" T13 ON ("tutelary_permissionset"."id" = T13."pset_id") INNER JOIN "tutelary_policyinstance" T16 ON ("tutelary_permissionset"."id" = T16."pset_id") INNER JOIN "tutelary_policyinstance" T19 ON ("tutelary_permissionset"."id" = T19."pset_id") INNER JOIN "tutelary_policyinstance" T22 ON ("tutelary_permissionset"."id" = T22."pset_id") INNER JOIN "tutelary_policyinstance" T25 ON ("tutelary_permissionset"."id" = T25."pset_id") INNER JOIN "tutelary_policyinstance" T28 ON ("tutelary_permissionset"."id" = T28."pset_id") INNER JOIN "tutelary_policyinstance" T31 ON ("tutelary_permissionset"."id" = T31."pset_id") INNER JOIN "tutelary_policyinstance" T34 ON ("tutelary_permissionset"."id" = T34."pset_id") INNER JOIN "tutelary_policyinstance" T37 ON ("tutelary_permissionset"."id" = T37."pset_id") WHERE ("tutelary_policyinstance"."policy_id" IN (1, 3, 4, 5) AND T4."policy_id" = 1 AND T4."role_id" IS NULL AND T4."variables" = '{}' AND T7."policy_id" = 4 AND T7."role_id" IS NULL AND T7."variables" = '{"organization": "daemeter"}' AND T10."policy_id" = 3 AND T10."role_id" IS NULL AND T10."variables" = '{"organization": "daemeter"}' AND T13."policy_id" = 4 AND T13."role_id" IS NULL AND T13."variables" = '{"organization": "itc-university-of-twente"}' AND T16."policy_id" = 3 AND T16."role_id" IS NULL AND T16."variables" = '{"organization": "itc-university-of-twente"}' AND T19."policy_id" = 4 AND T19."role_id" IS NULL AND T19."variables" = '{"organization": "programs"}' AND T22."policy_id" = 3 AND T22."role_id" IS NULL AND T22."variables" = '{"organization": "programs"}' AND T25."policy_id" = 4 AND T25."role_id" IS NULL AND T25."variables" = '{"organization": "david-4"}' AND T28."policy_id" = 5 AND T28."role_id" IS NULL AND T28."variables" = '{"organization": "david-4", "project": "legal-land-desk-1"}' AND T31."policy_id" = 4 AND T31."role_id" IS NULL AND T31."variables" = '{"organization": "kldmc"}' AND T34."policy_id" = 3 AND T34."role_id" IS NULL AND T34."variables" = '{"organization": "kldmc"}' AND T37."policy_id" = 5 AND T37."role_id" IS NULL AND T37."variables" = '{"organization": "david-4", "project": "customary-rights-1"}') GROUP BY "tutelary_permissionset"."id" HAVING COUNT("tutelary_policyinstance"."id") = 12 ORDER BY "tutelary_permissionset"."id" ASC LIMIT 1; args=(1, 3, 4, 5, 1, '{}', 4, '{"organization": "daemeter"}', 3, '{"organization": "daemeter"}', 4, '{"organization": "itc-university-of-twente"}', 3, '{"organization": "itc-university-of-twente"}', 4, '{"organization": "programs"}', 3, '{"organization": "programs"}', 4, '{"organization": "david-4"}', 5, '{"organization": "david-4", "project": "legal-land-desk-1"}', 4, '{"organization": "kldmc"}', 3, '{"organization": "kldmc"}', 5, '{"organization": "david-4", "project": "customary-rights-1"}', 12)
(0.000) INSERT INTO "tutelary_permissionset" ("anonymous_user") VALUES (false) RETURNING "tutelary_permissionset"."id"; args=(False,)
(0.000) UPDATE "tutelary_permissionset" SET "anonymous_user" = false WHERE "tutelary_permissionset"."id" = 5947; args=(False, 5947)
(0.001) INSERT INTO "tutelary_policyinstance" ("policy_id", "pset_id", "index", "role_id", "variables") VALUES (1, 5947, 0, NULL, '{}'), (4, 5947, 1, NULL, '{"organization": "daemeter"}'), (3, 5947, 2, NULL, '{"organization": "daemeter"}'), (4, 5947, 3, NULL, '{"organization": "itc-university-of-twente"}'), (3, 5947, 4, NULL, '{"organization": "itc-university-of-twente"}'), (4, 5947, 5, NULL, '{"organization": "programs"}'), (3, 5947, 6, NULL, '{"organization": "programs"}'), (4, 5947, 7, NULL, '{"organization": "david-4"}'), (5, 5947, 8, NULL, '{"organization": "david-4", "project": "legal-land-desk-1"}'), (4, 5947, 9, NULL, '{"organization": "kldmc"}'), (3, 5947, 10, NULL, '{"organization": "kldmc"}'), (5, 5947, 11, NULL, '{"organization": "david-4", "project": "customary-rights-1"}') RETURNING "tutelary_policyinstance"."id"; args=(1, 5947, 0, None, '{}', 4, 5947, 1, None, '{"organization": "daemeter"}', 3, 5947, 2, None, '{"organization": "daemeter"}', 4, 5947, 3, None, '{"organization": "itc-university-of-twente"}', 3, 5947, 4, None, '{"organization": "itc-university-of-twente"}', 4, 5947, 5, None, '{"organization": "programs"}', 3, 5947, 6, None, '{"organization": "programs"}', 4, 5947, 7, None, '{"organization": "david-4"}', 5, 5947, 8, None, '{"organization": "david-4", "project": "legal-land-desk-1"}', 4, 5947, 9, None, '{"organization": "kldmc"}', 3, 5947, 10, None, '{"organization": "kldmc"}', 5, 5947, 11, None, '{"organization": "david-4", "project": "customary-rights-1"}')
(0.000) SELECT "tutelary_permissionset_users"."user_id" FROM "tutelary_permissionset_users" WHERE ("tutelary_permissionset_users"."permissionset_id" = 5947 AND "tutelary_permissionset_users"."user_id" IN (243)); args=(5947, 243)
(0.001) INSERT INTO "tutelary_permissionset_users" ("permissionset_id", "user_id") VALUES (5947, 243) RETURNING "tutelary_permissionset_users"."id"; args=(5947, 243)
(0.000) UPDATE "tutelary_permissionset" SET "anonymous_user" = false WHERE "tutelary_permissionset"."id" = 5947; args=(False, 5947)
(0.000) UPDATE "django_session" SET "session_data" = 'ZjkxMzEwNDUzODdjZWY2NDhiN2VjZTgyYjI1NmM4ZjE5YzY4ZWM3Zjp7Il9hdXRoX3VzZXJfaWQiOiIyNDMiLCJfYXV0aF91c2VyX2JhY2tlbmQiOiJjb3JlLmJhY2tlbmRzLkF1dGgiLCJfYXV0aF91c2VyX2hhc2giOiJiMGM2MzZkY2ZmYTJkMDM1NGIzY2UzYjNhOWQ5MDg5YzkxM2EzYjc1IiwiX3Nlc3Npb25fZXhwaXJ5IjowfQ==', "expire_date" = '2017-12-04T21:14:31.459798+00:00'::timestamptz WHERE "django_session"."session_key" = 'gwu8kjrz2wl4wq7rv7p286ljwb8gonv9'; args=('ZjkxMzEwNDUzODdjZWY2NDhiN2VjZTgyYjI1NmM4ZjE5YzY4ZWM3Zjp7Il9hdXRoX3VzZXJfaWQiOiIyNDMiLCJfYXV0aF91c2VyX2JhY2tlbmQiOiJjb3JlLmJhY2tlbmRzLkF1dGgiLCJfYXV0aF91c2VyX2hhc2giOiJiMGM2MzZkY2ZmYTJkMDM1NGIzY2UzYjNhOWQ5MDg5YzkxM2EzYjc1IiwiX3Nlc3Npb25fZXhwaXJ5IjowfQ==', datetime.datetime(2017, 12, 4, 21, 14, 31, 459798, tzinfo=<UTC>), 'gwu8kjrz2wl4wq7rv7p286ljwb8gonv9')
10.0.2.2 - - [20/Nov/2017 21:14:31] "POST /account/login/ HTTP/1.1" 302 -
```
</details>

There have been some other small enhancements made along the way:

* Don't pin the required Django version
* use `enumerate()` rather than `itertools.count()`
