### PR TITLE
Add support for Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: false
 env:
     - TOX_ENV=py35-flake8
     - TOX_ENV=py35-docs
-    - TOX_ENV=py35-django1.9
+    - TOX_ENV=py35-django1.11
 
 matrix:
   fast_finish: true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,11 @@
+import os
+
+
 def pytest_configure():
     from django.conf import settings
+
+    BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    BASE_TEMPLATE_DIR = os.path.join(os.path.dirname(BASE_DIR), 'templates')
 
     settings.configure(
         DEBUG_PROPAGATE_EXCEPTIONS=True,
@@ -10,10 +16,6 @@ def pytest_configure():
         USE_I18N=True,
         USE_L10N=True,
         STATIC_URL='/static/',
-        TEMPLATE_LOADERS=(
-            'django.template.loaders.filesystem.Loader',
-            'django.template.loaders.app_directories.Loader',
-        ),
         MIDDLEWARE_CLASSES=(
             'django.middleware.common.CommonMiddleware',
             'django.contrib.sessions.middleware.SessionMiddleware',
@@ -39,7 +41,25 @@ def pytest_configure():
             'default': {
                 'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
             }
-        }
+        },
+        TEMPLATES=[
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'DIRS': [BASE_TEMPLATE_DIR],
+                'OPTIONS': {
+                    'context_processors': [
+                        'django.template.context_processors.debug',
+                        'django.template.context_processors.request',
+                        'django.contrib.auth.context_processors.auth',
+                        'django.contrib.messages.context_processors.messages',
+                    ],
+                    'loaders': [
+                        'django.template.loaders.filesystem.Loader',
+                        'django.template.loaders.app_directories.Loader'
+                    ],
+                },
+            },
+        ]
     )
 
     try:

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -1,7 +1,4 @@
-import os.path
-
 from django.core.exceptions import PermissionDenied
-import django.template.loader
 import django.views.generic as generic
 
 from tutelary.mixins import PermissionRequiredMixin
@@ -12,11 +9,6 @@ from django.test import RequestFactory
 from .factories import UserFactory, PolicyFactory
 from .datadir import datadir  # noqa
 from .filter_models import Org, Proj
-
-
-django.template.loader._engine_list(None)[0].engine.dirs = [
-    os.path.join(os.path.dirname(__file__), "templates")
-]
 
 
 class FakeQueryset:

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 envlist =
        py35-{flake8,docs},
-       py35-django1.9
+       py35-django1.11
 
 [testenv]
 commands = ./runtests.py --fast
 setenv =
        PYTHONDONTWRITEBYTECODE=1
 deps =
-       django1.9: Django==1.9
+       django1.11: Django>=1.11,<2.0
        pytest-django==2.9.1
        django-audit-log==0.7.0
        factory_boy==2.9.2
@@ -25,6 +25,6 @@ whitelist_externals=make
 commands = make -C docs html
 deps =
        Sphinx>=1.3.3
-       Django==1.9
+       Django>=1.11,<2.0
        django-audit-log==0.7.0
        djangorestframework==3.3.2


### PR DESCRIPTION
Adds changes to support Django 1.11. 

- Updates test envs to use Django 1.11.8.
- Fixes template loading for tests. Rather than loading templates inside `test_filtering.py`, we add `TEMPLATES` to the settings, so templates are discovered automatically. 